### PR TITLE
Fix login body format

### DIFF
--- a/nimbus.py
+++ b/nimbus.py
@@ -88,9 +88,9 @@ class NimbusClient:
         try:
             r = self.client.post(
                 "https://nimbusweb.me/auth/api/auth",
-                data={"login": email, "password": password},
+                json={"login": email, "password": password},
                 headers={
-                    "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+                    "Content-Type": "application/json; charset=UTF-8",
                     "Referer": "https://nimbusweb.me/auth",
                 },
             )


### PR DESCRIPTION
## Summary
- send JSON body when authenticating to Nimbus

## Testing
- `python -m py_compile nimbus.py`


------
https://chatgpt.com/codex/tasks/task_e_6887d7a8f19c8325aa716d77ed83c754