### PR TITLE
Reset counters when starting new scan

### DIFF
--- a/SEED_SEARCHER_FINAL_electrum_v3.py
+++ b/SEED_SEARCHER_FINAL_electrum_v3.py
@@ -874,6 +874,10 @@ class Main(QWidget):
             max_mb = 50
 
         self.list_valid.clear(); self.list_near.clear(); self.list_susp.clear(); self.log.clear()
+        self.count_seed = {12: 0, 15: 0, 18: 0, 24: 0}
+        self.count_electrum = 0
+        self.count_eth = 0
+        self._update_counters()
         self.progress_bar.setValue(0); self.progress_bar.setMaximum(0)
         self.btn_start.setEnabled(False); self.btn_stop.setEnabled(True); self.btn_export.setEnabled(False)
         self.seen_valid = {12:set(), 15:set(), 18:set(), 24:set()}


### PR DESCRIPTION
## Summary
- reset all counters when starting a new scan so the UI reflects a clean state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e68d89a59c832eb121b2641fa6f095