### PR TITLE
Fix Electrum logging duplication and counter updates

### DIFF
--- a/SEED_SEARCHER_FINAL_electrum_v3.py
+++ b/SEED_SEARCHER_FINAL_electrum_v3.py
@@ -950,10 +950,6 @@ class Main(QWidget):
                         self.log_electrum.appendPlainText(f"{phrase}  |  {path}")
                     except Exception:
                         pass
-                    try:
-                        self.log_electrum.appendPlainText(f"{phrase}  |  {path}")
-                    except Exception:
-                        pass
         except Exception:
             pass
 
@@ -995,13 +991,14 @@ class Main(QWidget):
                 seen_set = self.seen_electrum_12 if n == 12 else self.seen_electrum_24
                 if phrase not in seen_set:
                     seen_set.add(phrase)
+                    self.count_electrum += 1
+                    try:
+                        self._update_counters()
+                    except Exception:
+                        pass
                     fname = f"electrum_valid_{n}.txt"
                     with open(self.results_dir / fname, "a", encoding="utf-8") as f:
                         f.write(f"{phrase} | {path}\n")
-                    try:
-                        self.log_electrum.appendPlainText(f"{phrase}  |  {path}")
-                    except Exception:
-                        pass
                     try:
                         self.log_electrum.appendPlainText(f"{phrase}  |  {path}")
                     except Exception:


### PR DESCRIPTION
## Summary
- remove duplicate Electrum log entries when recording new seeds
- update Electrum counters when near matches are added to the Electrum list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e6af9c85fc832eb18b296ba550c54a