### PR TITLE
Add freeze support initialization before launching main

### DIFF
--- a/SEED_SEARCHER_FINAL_electrum_v3.py
+++ b/SEED_SEARCHER_FINAL_electrum_v3.py
@@ -29,7 +29,7 @@ import sys
 import tempfile
 from dataclasses import dataclass
 from datetime import datetime
-from multiprocessing import Pool, cpu_count
+from multiprocessing import Pool, cpu_count, freeze_support
 from pathlib import Path
 from typing import Iterable, List, Tuple, Dict, Set
 
@@ -1078,6 +1078,7 @@ def main():
     sys.exit(app.exec())
 
 if __name__ == "__main__":
+    freeze_support()
     main()
 # ---- Fatal error helper (shows dialog even without Qt) ----
 def _fatal_startup(msg: str):


### PR DESCRIPTION
## Summary
- import `freeze_support` from `multiprocessing`
- invoke `multiprocessing.freeze_support()` before calling `main()`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e6b3200f70832ebdc5c3a40817aa3f