### PR TITLE
Reset ETH counter between scans and update UI counts

### DIFF
--- a/SEED_SEARCHER_FINAL_electrum_v3.py
+++ b/SEED_SEARCHER_FINAL_electrum_v3.py
@@ -882,7 +882,8 @@ class Main(QWidget):
         self.seen_electrum_12 = set()
         self.seen_electrum_24 = set()
         self.seen_valid_12_typo = set()
-        
+        self.count_eth = 0
+
         # reset additional tracking sets
         import os as _os
         _os.environ['MF_STRICT_BREAKS'] = '1' if self.chk_strict.isChecked() else '0'
@@ -1017,6 +1018,8 @@ class Main(QWidget):
         try:
             with open(self.results_dir / "eth_keys_found.txt", "a", encoding="utf-8") as f:
                 f.write(f"{kind_value} | {path}\n")
+            self.count_eth += 1
+            self._update_counters()
         except Exception:
             pass
     


### PR DESCRIPTION
## Summary
- reset the ETH counter when starting a new scan so it reflects the fresh run
- increment the ETH counter and refresh the counters display after saving a new ETH result

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e6b359f994832ebd2620139ebf8390