### PR TITLE
Improve Electrum filtering and suspicious phrase heuristics

### DIFF
--- a/tests/test_seed_detection.py
+++ b/tests/test_seed_detection.py
@@ -31,10 +31,32 @@ def test_find_phrases_detects_various_lengths():
     }
 
     text = '\n'.join(mnemonics.values())
-    valid, near = mod.find_phrases_robust(text)
+    valid, near, electrum = mod.find_phrases_robust(text)
 
     assert not near
+    assert not electrum
     found = {len(v.split()): v for v in valid}
     assert set(found) == set(mnemonics)
     for length, phrase in mnemonics.items():
         assert found[length] == phrase
+
+
+def test_electrum_phrases_are_separated_and_checked():
+    electrum_phrase = (
+        "jungle patient foster select unit chase regret local romance oyster vanish act"
+    )
+    assert mod.is_electrum_new_seed(electrum_phrase)
+    text = f"header\n{electrum_phrase}\nfooter"
+    valid, near, electrum = mod.find_phrases_robust(text)
+
+    assert electrum == [electrum_phrase]
+    assert not valid
+    assert electrum_phrase in near
+
+
+def test_repeated_words_mark_phrase_suspicious():
+    phrase = (
+        "little boy twenty hello there little girl tiger there little girl tiger "
+        "hello there little boy mind there"
+    )
+    assert mod.is_suspicious(phrase)


### PR DESCRIPTION
## Summary
- return Electrum-validated phrases separately from near BIP-39 results and process them with checksum verification
- tighten the suspicious phrase heuristic to catch phrases with multiple repeated words before reporting them
- add unit coverage for Electrum extraction and the updated suspicious-word detection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e6cdcd7998832ea11c9b7cf87e0415